### PR TITLE
Fix inconsistent state after discard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Race condition after discarding a transaction
+
 ## Release 1.4.5 (2017-11-08)
 
 ### Features

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ The following is a list of people who have contributed to
 - Christoph Tavan <dev@tavan.de>
 - Dana Powers <dana.powers@rd.io>
 - Dan Bravender <dan.bravender@gmail.com>
+- Dolan Murvihill <dmurvihill@everquote.com>
 - dgvncsz0f <dsouza@c0d3.xxx>
 - Evgeny Tataurov <tatauroff@gmail.com>
 - Gleicon Moraes <gleicon@gmail.com>

--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1524,8 +1524,11 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
             raise RedisError("Not in transaction")
         self.post_proc = []
         self.transactions = 0
+        return self.execute_command("DISCARD").addBoth(self._finish_discard)
+
+    def _finish_discard(self, response):
         self._clear_txstate()
-        return self.execute_command("DISCARD")
+        return response
 
     # Returns a proxy that works just like .multi() except that commands
     # are simply buffered to be written all at once in a pipeline.


### PR DESCRIPTION
the _clear_txstate() method is called from discard without waiting for
the 'DISCARD' command to complete on the server side. This results in a
brief period where the client in in an inconsistent state: the
transaction has been cleared on the client and the connection has been
returned to the connection pool, but the transaction is still open on
the server.

If another client grabs the connection during this period and tries to
start its own transaction during this period, it creates a race
condition between the DISCARD and the MULTI. If the MULTI is executed
first on the server, it causes an '(error) ERR MULTI calls can not be
nested' response error.

Instead, make _clear_txstate a callback for the discard method,
guaranteeing that the connection is not returned to the queue until the
transaction is well and truly discarded. Make sure to pass the response
through to ensure backward compatibility.